### PR TITLE
[FEATURE] Added a copy button to the SVG code snippet for easy copying

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -18,6 +18,28 @@ document.addEventListener("DOMContentLoaded", () => {
             }
         }
     }
+
+    document.querySelectorAll('.copy-btn').forEach((button) => {
+        button.addEventListener('click', () => {
+            const codeBlock = button.nextElementSibling?.querySelector('code');
+
+            if (codeBlock) {
+                const textToCopy = codeBlock.textContent.trim();
+
+                navigator.clipboard
+                    .writeText(textToCopy)
+                    .then(() => {
+                        button.textContent = 'Copied!';
+                        setTimeout(() => {
+                            button.textContent = 'Copy';
+                        }, 2000);
+                    })
+                    .catch((error) => {
+                        console.error('Failed to copy text:', error);
+                    });
+            }
+        });
+    });
 });
 
 // Theme

--- a/assets/scss/docs/_misc.scss
+++ b/assets/scss/docs/_misc.scss
@@ -48,3 +48,47 @@
         font-family: monospace;
     }
 }
+
+/* Container for Code Block */
+.code-container {
+    position: relative;
+    border-radius: 6px;
+    font-family: monospace;
+    overflow: hidden;
+
+    /* Code Block */
+    .code-block {
+        margin: 0;
+        padding: 16px;
+        overflow-x: auto;
+        font-size: 14px;
+        line-height: 1.5;
+    }
+
+    /* Copy Button */
+    .copy-btn {
+        position: absolute;
+        top: 8px;
+        right: 8px;
+        padding: 4px 8px;
+        font-size: 12px;
+        color: #24292f;
+        background-color: #f3f4f6;
+        border: 1px solid #d0d7de;
+        border-radius: 6px;
+        cursor: pointer;
+        box-shadow:
+            0 1px 0 rgba(27, 31, 35, 0.04),
+            inset 0 1px 0 rgba(255, 255, 255, 0.25);
+
+        &:hover {
+            background-color: #e1e4e8;
+            border-color: #c9d1d9;
+        }
+
+        &:active {
+            background-color: #d7dbe0;
+            box-shadow: inset 0 1px 0 rgba(27, 31, 35, 0.15);
+        }
+    }
+}

--- a/tmpl/html/docs/_makros.html.twig
+++ b/tmpl/html/docs/_makros.html.twig
@@ -1,3 +1,6 @@
 {% macro codeblock(markup, language = 'html') %}
-    <pre class="p-3 rounded bg-adapt-light"><code class="language-{{ language }}">{{ markup|trim|escape }}</code></pre>
+    <div class="code-container position-relative">
+        <button class="copy-btn" aria-label="Copy code" title="Copy">Copy</button>
+        <pre class="p-3 rounded bg-adapt-light code-block"><code class="language-{{ language }}">{{ markup|trim|escape }}</code></pre>
+    </div>
 {% endmacro %}


### PR DESCRIPTION
Hi @benjaminkott 

As requested in #330, I've added a copy button to the SVG code snippets. This should significantly improve the user experience by allowing developers to easily copy the code for their projects.

Please review the implementation as shown in the attached screenshot. Let me know if any changes are needed.

![image](https://github.com/user-attachments/assets/7e43fb85-2c2e-4240-8c8d-f52aa3888145)

Thanks,





