### PR TITLE
[FEATURE] Add version filter

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -37,6 +37,30 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     }
 
+    document.querySelectorAll('.btn-check[data-version]').forEach(el => {
+        el.addEventListener('change', () => {
+            const activeVersions = Array.from(
+                document.querySelectorAll('.btn-check[data-version]:checked')
+            ).map(e => e.dataset.version);
+
+            const items = document.querySelectorAll('[data-versions]');
+
+            items.forEach((item) => {
+                const versions = item.dataset.versions
+                    .trim()
+                    .split(/\s+/);
+
+                const match =
+                    activeVersions.length === 0
+                        ? true
+                        : activeVersions.some(v => versions.includes(v));
+
+                item.classList.toggle('d-none', !match);
+            });
+
+        });
+    });
+
     document.querySelectorAll('.code-copy-btn').forEach((button) => {
         button.addEventListener('click', () => {
             const codeBlock = button.nextElementSibling?.querySelector('code');

--- a/assets/scss/docs.scss
+++ b/assets/scss/docs.scss
@@ -5,3 +5,4 @@
 @import 'docs/iconstage';
 @import 'docs/preview';
 @import 'docs/misc';
+@import "docs/version-filter";

--- a/assets/scss/docs/_version-filter.scss
+++ b/assets/scss/docs/_version-filter.scss
@@ -1,0 +1,16 @@
+.version-badge {
+    cursor: pointer;
+    user-select: none;
+    transition: all .2s ease;
+    opacity: .6;
+}
+
+/* checked state */
+.btn-check:checked + .version-badge {
+    opacity: 1;
+}
+
+/* hover */
+.version-badge:hover {
+    opacity: .85;
+}

--- a/tmpl/html/docs/_filters.html.twig
+++ b/tmpl/html/docs/_filters.html.twig
@@ -7,5 +7,26 @@
         </label>
     </div>
     {%- endif -%}
-    <input class="form-control search mb-0" id="search" placeholder="Start typing to filter..." autocomplete="off">
+    {%- if showVersionFilter is not defined or showVersionFilter -%}
+        <div class="d-flex flex-wrap gap-2">
+            <span class="me-2">Available in TYPO3</span>
+            {%- for typo3version, version in typo3.versions -%}
+                <input
+                    type="checkbox"
+                    class="btn-check"
+                    id="version-{{ typo3version }}"
+                    autocomplete="off"
+                    data-version="{{ typo3version }}"
+                >
+
+                <label
+                    class="badge bg-primary version-badge"
+                    for="version-{{ typo3version }}"
+                >
+                    {{ typo3version }}
+                </label>
+            {%- endfor -%}
+        </div>
+    {%- endif -%}
+    <input class="form-control search mb-0 flex-shrink-0 w-auto" style="min-width: 220px;" id="search" placeholder="Start typing to filter..." autocomplete="off">
 </div>

--- a/tmpl/html/docs/index.html.twig
+++ b/tmpl/html/docs/index.html.twig
@@ -12,7 +12,7 @@
         <h2 class="mb-0">Icons</h2>
         {%- include '_filters.html.twig' -%}
     </div>
-
+    
     <div class="icongrid" id="iconlist">
         {%- for category in categories -%}
             {%- for iconIdentifier in category.icons -%}
@@ -22,6 +22,7 @@
                         data-type="icon"
                         data-identifier="{{ icon.identifier }}"
                         data-search="{{ icon.identifier }} {{ icon._meta.tags|join(' ') }}"
+                        data-versions="{%- for typo3version, version in typo3.versions -%}{%- if version in icon._meta.changes %}{{ typo3version }} {% endif -%}{%- endfor -%}"
                         {% if icon._meta.bidi %}data-bidi="true"{% endif %}
                         href="{{ pathPrefix }}icons/{{ category.identifier }}/{{ icon.identifier }}.html"
                         title="{{ icon.identifier }}"

--- a/tmpl/html/docs/section.html.twig
+++ b/tmpl/html/docs/section.html.twig
@@ -11,7 +11,7 @@
 
     <div class="d-flex mb-4 align-items-center">
         <h2 class="mb-0">{{ category.title }}</h2>
-        {%- include '_filters.html.twig' with { showBidiFilter: not category.rendering.menuview } -%}
+        {%- include '_filters.html.twig' with { showBidiFilter: not category.rendering.menuview, showVersionFilter: not category.rendering.menuview } -%}
     </div>
 
     {%- if category.rendering.menuview -%}


### PR DESCRIPTION
This PR introduces a set of toggleable version badges that allow filtering icons based on the TYPO3 versions in which they are available.

- Adds version filter checkboxes styled as badges
- Supports multi-select filtering (OR logic across selected versions)
- Filters icons based on data-versions attribute
- Integrates seamlessly with existing BiDi filter and search input

<img width="1461" height="129" alt="image" src="https://github.com/user-attachments/assets/7038c998-c660-4611-bd20-1bceb19f0ece" />
